### PR TITLE
package will not work on react native < 0..47

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": ">=15.3.1",
-    "react-native": ">=0.35"
+    "react-native": ">=0.47"
   },
   "bugs": {
     "url": "https://github.com/taessina/react-native-paypal-wrapper/issues"


### PR DESCRIPTION
hello,

thanks for creating this package.

i was having issues with getting this library to work on a react native version below 0.47. i think it is due to a function being deprecated. i noticed you had a commit that resolved this issue. you may need to also update the minimum version in the package.json.

thanks