### PR TITLE
update to enable card.io package and more

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -25,7 +26,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile ('com.paypal.sdk:paypal-android-sdk:2.15.1') {
-        exclude group: 'io.card'
-    }
+    compile 'com.paypal.sdk:paypal-android-sdk:2.15.1'
 }

--- a/ios/RNPaypalWrapper.m
+++ b/ios/RNPaypalWrapper.m
@@ -106,7 +106,7 @@ RCT_EXPORT_METHOD(pay:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)r
     [self.payment setShortDescription:description];
     
     self.configuration = [[PayPalConfiguration alloc] init];
-    [self.configuration setAcceptCreditCards:false];
+    [self.configuration setAcceptCreditCards:true];
     [self.configuration setPayPalShippingAddressOption:PayPalShippingAddressOptionPayPal];
     
     PayPalPaymentViewController *vc = [[PayPalPaymentViewController alloc] initWithPayment:self.payment


### PR DESCRIPTION
I noticed card payments were disabled.  seems like  "acceptCreditCards" on PayPalConfiguration will only default to true when: "io.card" package is included.

    public static boolean d() {
        try {
            Class.forName("io.card.payment.CardIOActivity");
            return true;
        } catch (Exception var0) {
            return false;
        }
    }

* this the default for acceptCreditCard in the android paypal library

I have tried to include the library "card.io". I noticed it was excluded in the build.gradle. I did not notice any issues when trying to include it. So I assume it will work ok. I have tested on android and I am able to see the pay by card button and I am also able to scan cards fine.

other updates:
- changed build.gradle build properties to use ext "rootProject.ext.*" so no conflict is created with react native project and this module