### PR TITLE
Add requiresMainQueueSetup in RNPaypalWrapper.m

### DIFF
--- a/ios/RNPaypalWrapper.m
+++ b/ios/RNPaypalWrapper.m
@@ -172,4 +172,8 @@ RCT_EXPORT_METHOD(pay:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)r
     }];
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 @end


### PR DESCRIPTION
This removes the warning on iOS because of constantsToExports.